### PR TITLE
Add support for online bot discovery via registry

### DIFF
--- a/src/main/kotlin/net/bjoernpetersen/musicbot/spi/domain/DomainHandler.kt
+++ b/src/main/kotlin/net/bjoernpetersen/musicbot/spi/domain/DomainHandler.kt
@@ -1,7 +1,7 @@
 package net.bjoernpetersen.musicbot.spi.domain
 
 /**
- * Keeps track of Ip Addresses and domains the MusicBot is accessible by.
+ * Keeps track of IP addresses and domains the MusicBot is accessible by.
  */
 interface DomainHandler {
     /**

--- a/src/main/kotlin/net/bjoernpetersen/musicbot/spi/domain/DomainHandler.kt
+++ b/src/main/kotlin/net/bjoernpetersen/musicbot/spi/domain/DomainHandler.kt
@@ -1,0 +1,12 @@
+package net.bjoernpetersen.musicbot.spi.domain
+
+/**
+ * Keeps track of IpAddresses and Domains the MusicBot is accessible by.
+ */
+interface DomainHandler {
+    /**
+     * Returns a map of IpAddress strings to domain names.
+     * Used to register the MusicBot at a registry.
+     */
+    val ipDomains: Map<String, String>
+}

--- a/src/main/kotlin/net/bjoernpetersen/musicbot/spi/domain/DomainHandler.kt
+++ b/src/main/kotlin/net/bjoernpetersen/musicbot/spi/domain/DomainHandler.kt
@@ -1,12 +1,12 @@
 package net.bjoernpetersen.musicbot.spi.domain
 
 /**
- * Keeps track of IpAddresses and Domains the MusicBot is accessible by.
+ * Keeps track of Ip Addresses and domains the MusicBot is accessible by.
  */
 interface DomainHandler {
     /**
-     * Returns a map of IpAddress strings to domain names.
+     * Returns a map of Ip address strings to domain names.
      * Used to register the MusicBot at a registry.
      */
-    val ipDomains: Map<String, String>
+    fun getDomainByIp(): Map<String, String>
 }

--- a/src/main/kotlin/net/bjoernpetersen/musicbot/spi/domain/DomainHandler.kt
+++ b/src/main/kotlin/net/bjoernpetersen/musicbot/spi/domain/DomainHandler.kt
@@ -5,7 +5,7 @@ package net.bjoernpetersen.musicbot.spi.domain
  */
 interface DomainHandler {
     /**
-     * Returns a map of Ip address strings to domain names.
+     * Returns a map of IP address strings to domain names.
      * Used to register the MusicBot at a registry.
      */
     fun getDomainByIp(): Map<String, String>

--- a/src/main/kotlin/net/bjoernpetersen/musicbot/spi/version/Version.kt
+++ b/src/main/kotlin/net/bjoernpetersen/musicbot/spi/version/Version.kt
@@ -1,25 +1,46 @@
 package net.bjoernpetersen.musicbot.spi.version
 
 /**
- * Constains version information about the MusicBot instance
+ * Contains version information about the MusicBot instance
  */
-interface Version {
+data class Version (
     /**
-     * Return the VersionInfo
+     * Version information about the bot
      */
     val versionInfo: VersionInfo
-}
+)
 
 /**
  * Contains information about API version, name of the MusicBot instance and implementation information
  */
 data class VersionInfo(
+    /**
+     * The API version
+     */
     val apiVersion: String,
+    /**
+     * A user-friendly name for the bot instance. May be customized per instance.
+     */
     val botName: String,
+    /**
+     * Information about the implementation serving the API.
+     */
     val implementation: ImplementationInfo
 )
 
 /**
  * Implementation information about the MusicBot
  */
-data class ImplementationInfo(val projectInfo: String, val name: String, val version: String)
+data class ImplementationInfo(
+    /**
+     * The name of the server implementation.
+     */
+    val projectInfo: String,
+    /**
+     * The version of the implementation.
+     */
+    val name: String,
+    /**
+     * URL to the project website.
+     */
+    val version: String)

--- a/src/main/kotlin/net/bjoernpetersen/musicbot/spi/version/Version.kt
+++ b/src/main/kotlin/net/bjoernpetersen/musicbot/spi/version/Version.kt
@@ -17,9 +17,9 @@ data class Version(
 /**
  * Implementation information about the MusicBot
  *
- * @param projectInfo The name of the server implementation.
- * @param name The version of the implementation.
- * @param version URL to the project website.
+ * @param projectInfo URL to the project website.
+ * @param name The name of the server implementation.
+ * @param version The version of the implementation.
  */
 data class ImplementationInfo(
     val projectInfo: String,

--- a/src/main/kotlin/net/bjoernpetersen/musicbot/spi/version/Version.kt
+++ b/src/main/kotlin/net/bjoernpetersen/musicbot/spi/version/Version.kt
@@ -1,0 +1,25 @@
+package net.bjoernpetersen.musicbot.spi.version
+
+/**
+ * Constains version information about the MusicBot instance
+ */
+interface Version {
+    /**
+     * Return the VersionInfo
+     */
+    val versionInfo: VersionInfo
+}
+
+/**
+ * Contains information about API version, name of the MusicBot instance and implementation information
+ */
+data class VersionInfo(
+    val apiVersion: String,
+    val botName: String,
+    val implementation: ImplementationInfo
+)
+
+/**
+ * Implementation information about the MusicBot
+ */
+data class ImplementationInfo(val projectInfo: String, val name: String, val version: String)

--- a/src/main/kotlin/net/bjoernpetersen/musicbot/spi/version/Version.kt
+++ b/src/main/kotlin/net/bjoernpetersen/musicbot/spi/version/Version.kt
@@ -1,46 +1,28 @@
 package net.bjoernpetersen.musicbot.spi.version
 
 /**
- * Contains version information about the MusicBot instance
- */
-data class Version (
-    /**
-     * Version information about the bot
-     */
-    val versionInfo: VersionInfo
-)
-
-/**
  * Contains information about API version, name of the MusicBot instance and implementation information
+ *
+ * @param apiVersion The API version
+ * @param botName A user-friendly name for the bot instance. May be customized per instance.
+ * @param implementation Information about the implementation serving the API.
+ *
  */
-data class VersionInfo(
-    /**
-     * The API version
-     */
+data class Version(
     val apiVersion: String,
-    /**
-     * A user-friendly name for the bot instance. May be customized per instance.
-     */
     val botName: String,
-    /**
-     * Information about the implementation serving the API.
-     */
     val implementation: ImplementationInfo
 )
 
 /**
  * Implementation information about the MusicBot
+ *
+ * @param projectInfo The name of the server implementation.
+ * @param name The version of the implementation.
+ * @param version URL to the project website.
  */
 data class ImplementationInfo(
-    /**
-     * The name of the server implementation.
-     */
     val projectInfo: String,
-    /**
-     * The version of the implementation.
-     */
     val name: String,
-    /**
-     * URL to the project website.
-     */
-    val version: String)
+    val version: String
+)


### PR DESCRIPTION
Add interfaces to support online registration of the instance.

New interfaces:
 - `DomainHandler`: keeps track of ip addesses and domains the musicbot is accessible at
 - `Version`: Version information. Everything that should be available at /version